### PR TITLE
delete audio file once analized

### DIFF
--- a/server.js
+++ b/server.js
@@ -2,9 +2,11 @@ const express = require("express");
 const multer = require("multer");
 const fs = require("fs-extra");
 const cors = require("cors");
+const path = require("path");
 
 const app = express();
 app.use(cors());
+app.use(express.json());
 const upload = multer({ dest: "uploads/" });
 
 app.post("/upload", upload.single("file"), async (req, res) => {
@@ -28,6 +30,25 @@ app.post("/upload", upload.single("file"), async (req, res) => {
     });
   } else {
     res.status(400).send("Por favor subir un archivo MP3");
+  }
+});
+
+app.post("/deleteFile", async (req, res) => {
+  const targetFolder = "/app/data";
+  const filename = req.body.filename;
+
+  if (fs.existsSync(path.join(targetFolder, filename))) {
+    fs.unlink(path.join(targetFolder, filename), (err) => {
+      if (err) {
+        console.error("Error borrando el archivo:", err);
+        res.status(500).send("Error borrando el archivo");
+      } else {
+        console.log("Archivo borrado exitosamente");
+        res.status(200).send("Archivo borrado exitosamente");
+      }
+    });
+  } else {
+    res.status(404).send("Archivo no encontrado");
   }
 });
 

--- a/src/App.js
+++ b/src/App.js
@@ -61,10 +61,29 @@ const App = () => {
       setChatId(result.chat_id)
       addMessage("bot", "Audio listo. Hazme una pregunta")
 
+      try {
+        const response = await fetch("http://localhost:3001/deleteFile", {
+          method: "POST",
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({filename: `${file.path}`}),
+        });
+  
+        if (response.ok) {
+          console.log("Archivo borrado exitosamente");
+        } else {
+          console.error("Error borrando el archivo");
+        }
+      } catch (error) {
+        console.error("Error borrando el archivo:", error);
+      }
+
     } else {
       console.error("Error:", audio.statusText);
     }
-  
+
+
     } else {
       console.error("Por favor subir un archivo MP3");
     }


### PR DESCRIPTION
This PR adds an endpoint to the 'server.js' script so that the audio file is removed once transcribed, allowing the user to upload the same file multiple times without getting an error, and also preventing it from storing duplicate files